### PR TITLE
chore: update display-notification to v3

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ const path = require('path');
 const process = require('process');
 const util = require('util');
 const { Buffer } = require('buffer');
-const displayNotification = require('display-notification');
 const getPort = require('get-port');
 const nodemailer = require('nodemailer');
 const open = require('open');
@@ -89,6 +88,7 @@ const previewEmail = async (message, options) => {
   // `xcrun simctl openurl booted ${url}`
   //
   if (isMacOS && !isCI && options.openSimulator) {
+    const { displayNotification } = await import('display-notification');
     try {
       // <https://github.com/sindresorhus/open/blob/05ba9e150cc1a2629e518a9cc19b586c6ca3f269/index.js#L205-L222>
       const simulator = childProcess.spawn('open', ['-a', 'Simulator']);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "dependencies": {
     "ci-info": "^3.8.0",
-    "display-notification": "2.0.0",
+    "display-notification": "^3.0.0",
     "fixpack": "^4.0.0",
     "get-port": "5.1.1",
     "mailparser": "^3.7.1",


### PR DESCRIPTION
Updating the `display-notification` package from `2.0.0` to `3.0.0` to clear Sonatype violation `sonatype-2019-0206`